### PR TITLE
1.0.1 - Add support for tag immutability and scan on pushing + tf-0.12 sintaxt update

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,12 @@ locals {
 resource "aws_ecr_repository" "this" {
   count = var.create ? 1 : 0
   name  = local.ecr_repo_name
+  
+  image_tag_mutability = var.image_tag_mutability
+  
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_pushing
+  }
 }
 
 # ecs_ecr_read_perms defines the regular read and login perms for principals defined in var.allowed_read_principals

--- a/main.tf
+++ b/main.tf
@@ -6,9 +6,9 @@ locals {
 resource "aws_ecr_repository" "this" {
   count = var.create ? 1 : 0
   name  = local.ecr_repo_name
-  
+
   image_tag_mutability = var.image_tag_mutability
-  
+
   image_scanning_configuration {
     scan_on_push = var.scan_on_pushing
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,19 @@
 output "repository_arn" {
-  value       = "${element(concat(aws_ecr_repository.this.*.arn, list("")), 0)}"
+  value       = element(concat(aws_ecr_repository.this.*.arn, list("")), 0)
   description = "Repository ARN"
 }
 
 output "repository_name" {
-  value       = "${element(concat(aws_ecr_repository.this.*.name, list("")), 0)}"
+  value       = element(concat(aws_ecr_repository.this.*.name, list("")), 0)
   description = "Repository name"
 }
 
 output "registry_id" {
-  value       = "${element(concat(aws_ecr_repository.this.*.registry_id, list("")), 0)}"
+  value       = element(concat(aws_ecr_repository.this.*.registry_id, list("")), 0)
   description = "Registry ID"
 }
 
 output "registry_url" {
-  value       = "${element(concat(aws_ecr_repository.this.*.repository_url, list("")), 0)}"
+  value       = element(concat(aws_ecr_repository.this.*.repository_url, list("")), 0)
   description = "Registry URL"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,12 +19,12 @@ variable "name" {
 
 variable "allowed_read_principals" {
   description = "allowed_read_principals defines which external principals are allowed to read from the ECR repository"
-  type        = "list"
+  type        = list
 }
 
 variable "allowed_write_principals" {
   description = "allowed_write_principals defines which external principals are allowed to write to the ECR repository"
-  type        = "list"
+  type        = list
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,3 +37,13 @@ variable "lifecycle_policy_rules" {
   description = "List of json lifecycle policy rules, created by another module: doingcloudright/ecr-lifecycle-policy-rule/aws"
   default     = []
 }
+
+variable "image_tag_mutability" {
+  description = "The tag mutability setting for the repository. Must be one of: MUTABLE or IMMUTABLE."
+  default     = "MUTABLE"
+}
+
+variable "scan_on_pushing" {
+  description = "Indicates whether images are scanned after being pushed to the repository (true) or not scanned (false)."
+  default     = false
+}


### PR DESCRIPTION
#### Commits on Dec 04, 2019
- lnhc-delpfa01 - obey TF 0.12 syntax - f9d6890

#### Commits on Jan 27, 2020
- @diego-ojeda-binbash - Add support for tag immutability and scan on pushing. - c057020

#### Commits on Jan 28, 2020
- maartenvanderhoef - Merge pull request doingcloudright#12 from fabiendelpierre/tf-0.12 Suppress TF 0.12.14+ language deprecation warnings - 314a258
- @diego-ojeda-binbash - Fix format. - a04190a
- maartenvanderhoef - Merge pull request doingcloudright#13 from binbashar/mutability-and-scan-support - a253e54